### PR TITLE
Emit a 'meta' event with publish metadata (pkg name, version, current npm user)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feel like npm is drunk or maybe you are and want to verify what gets published v
 ```sh
 ➝ irish-pub
 
-npm publish will include the following files:
+npm will publish irish-pub@1.0.0 as thlorenz, including the following files:
 
 package.json
 .npmignore

--- a/bin/irish-pub.js
+++ b/bin/irish-pub.js
@@ -2,7 +2,12 @@
 'use strict';
 var irishPub = require('../')
 
-process.stdout.write('npm publish will include the following files:\n\n');
 irishPub(process.cwd())
-  .on('error', function (err) { console.error(err) })
-  .pipe(process.stdout)
+.on('metadata', function(meta) {
+  var details = meta.name + '@' + meta.version + ' as ' + meta.user;
+  console.log('npm will publish ' + details + ', including the following files:\n');
+})
+.on('error', function (err) {
+  console.error(err);
+})
+.pipe(process.stdout)

--- a/test/foo/package.json
+++ b/test/foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foo",
-  "version": "0.0.0",
+  "version": "1.2.3",
   "description": "This pack has a .gitignore and no .npmignore",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -12,10 +12,17 @@ function inspect(obj, depth) {
 
 test('\nfoo with .gitignore and no .npmignore', function (t) {
   var entries = []
-
+  t.plan(4);
   irishPub(root)
     .on('error', t.fail.bind(t))
-    .on('data', function (d) { entries.push(d.toString()) })
+    .on('metadata', function(meta) {
+      t.equal(meta.name, 'foo');
+      t.equal(meta.version, '1.2.3');
+      t.type(meta.user, 'string');
+    })
+    .on('data', function (d) {
+      entries.push(d.toString());
+    })
     .on('end', function () {
       t.deepEqual(
           entries
@@ -23,7 +30,7 @@ test('\nfoo with .gitignore and no .npmignore', function (t) {
             '.npmignore\n',
             'index.js\n',
             'example/first.js\n',
-            'lib/work.js\n' ] 
+            'lib/work.js\n' ]
         , 'emits all files that would be published'
       )
       t.end()


### PR DESCRIPTION
As proposed in #1, it now outputs:

```
npm would publish irish-pub@1.0.0 as thlorenz

package.json
README.md
...
```
- I went with a new `metadata` event which is easy to react to (see `irish-pub.js` binary)
- Added a test to cover the new event (does it need more?)
- I also switched the `npm pack` error to be emitted on the stream like the others, so that people using `irish-pub` as a library can also handle it
