### PR TITLE
Ignore prepublish output

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ function irishPub(root) {
 }
 
 function getMetadata(root, callback) {
-  exec('npm whoami', function (err, stderr, stdout) {
+  exec('npm whoami', function (err, stdout, stderr) {
     if (err) return callback('Cannot get current npm user');
-    var npmUser = stderr.trim();
+    var npmUser = stdout.trim();
     var packagePath = path.join(root, 'package.json');
     try {
       var pkg = require(packagePath);
@@ -49,11 +49,11 @@ function getMetadata(root, callback) {
 }
 
 function listFiles(root, out) {
-  exec('npm pack ' + root, function (err, stderr, stdout) {
+  exec('npm pack ' + root, function (err, stdout, stderr) {
     if (err) return out.emit('error', 'Failed to pack archive: ' + err);
 
-    // npm logs created filename on stderr
-    var tarFile = path.join(process.cwd(), stderr.trim());
+    // npm logs created filename on stdout
+    var tarFile = path.join(process.cwd(), stdout.trim().split(/\n+/).pop());
 
     fs.createReadStream(tarFile)
       .on('error', out.emit.bind(out, 'error'))

--- a/test/bar/package.json
+++ b/test/bar/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bar",
+  "version": "1.2.3",
+  "description": "This package has a prepublish script",
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "echo bar",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -4,13 +4,12 @@
 var test = require('tap').test
   , irishPub = require('../')
 
-var root = __dirname + '/foo';
-
 function inspect(obj, depth) {
   console.error(require('util').inspect(obj, false, depth || 5, true));
 }
 
 test('\nfoo with .gitignore and no .npmignore', function (t) {
+  var root = __dirname + '/foo';
   var entries = []
   t.plan(4);
   irishPub(root)
@@ -31,6 +30,26 @@ test('\nfoo with .gitignore and no .npmignore', function (t) {
             'index.js\n',
             'example/first.js\n',
             'lib/work.js\n' ]
+        , 'emits all files that would be published'
+      )
+      t.end()
+    });
+})
+
+test('bar with prepublish script', function (t) {
+  var root = __dirname + '/bar';
+  var entries = []
+  t.plan(1);
+  irishPub(root)
+    .on('error', t.fail.bind(t))
+    .on('data', function (d) {
+      entries.push(d.toString());
+    })
+    .on('end', function () {
+      t.deepEqual(
+          entries
+        , [ 'package.json\n',
+            'index.js\n' ]
         , 'emits all files that would be published'
       )
       t.end()


### PR DESCRIPTION
First commit corrects the callback signature from `exec(cmd, cb(err, stderr, stdout))` to `exec(cmd, cb(err, stdout, stderr))`.

Second commit takes the tar filename from the last line of `npm pack` output. Because if you have a `prepublish` script, `npm pack` output can contain tests etc:

```
> my-package@1.0.0 prepublish /somewhere/my-package
> npm t

> my-package@1.0.0 test /somewhere/my-package
> tape test/*.js

TAP version 13
# basic
ok 1 should be equal

1..1
# tests 1
# pass  1

# ok

my-package-1.0.0.tgz
```
