### PR TITLE
Fix: report package.json parse problems

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function getMetadata(root, callback) {
     try {
       var pkg = require(packagePath);
     } catch (ex) {
-      return callback('error', 'Invalid package: ' + packagePath);
+      return callback('Invalid package: ' + ex);
     }
     callback(null, {
       name: pkg.name,


### PR DESCRIPTION
Previously, we were just reporting "error" when there was a package parse error. This fixes things to actually report the error.
