### PR TITLE
test with node-installed npm and include node 6/8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "6"
+  - "8"
 install:
-  - npm install -g npm
   - npm install


### PR DESCRIPTION
The latest npm is not compatible with old versions of Node.js. And we should cover new versions of Node.js.